### PR TITLE
Adds new property to turn replace all confirmation prompt on and off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vs
+
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
 [Bb]in/
 [Oo]bj/
@@ -59,7 +61,7 @@ _ReSharper*
 *.ncrunch*
 .*crunch*.local.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in

--- a/FindReplace/FindReplace.cs
+++ b/FindReplace/FindReplace.cs
@@ -214,7 +214,16 @@ namespace FindReplace
         public static readonly DependencyProperty OwnerWindowProperty =
             DependencyProperty.Register("OwnerWindow", typeof(Window), typeof(FindReplaceMgr), new UIPropertyMetadata(null));
 
-        
+        /// <summary>
+        /// Determines whether to display the confirmation Prompt when pressing replace all
+        /// </summary>
+        public bool ShowReplaceAllConfirmationPrompt
+        {
+            get { return (bool)GetValue(ShowReplaceAllConfirmationPromptProperty); }
+            set { SetValue(ShowReplaceAllConfirmationPromptProperty, value); }
+        }
+        public static readonly DependencyProperty ShowReplaceAllConfirmationPromptProperty =
+            DependencyProperty.Register("ShowReplaceAllPrompt", typeof(bool), typeof(FindReplaceMgr), new UIPropertyMetadata(true));
 
         #endregion
 
@@ -274,12 +283,12 @@ namespace FindReplace
             return r;
         }
 
-        public void ReplaceAll(bool AskBefore = true)
+        public void ReplaceAll()
         {
             IEditor CE = GetCurrentEditor();
             if (CE == null) return;
 
-            if (!AskBefore || MessageBox.Show("Do you really want to replace all occurences of '" + TextToFind + "' with '" + ReplacementText + "'?",
+            if (!ShowReplaceAllConfirmationPrompt || MessageBox.Show("Do you really want to replace all occurences of '" + TextToFind + "' with '" + ReplacementText + "'?",
                 "Replace all", MessageBoxButton.YesNoCancel, MessageBoxImage.Exclamation) == MessageBoxResult.Yes)
             {
                 object InitialEditor = CurrentEditor;

--- a/FindReplaceUnitTests/FindReplaceVMTest.cs
+++ b/FindReplaceUnitTests/FindReplaceVMTest.cs
@@ -182,13 +182,15 @@ namespace FindReplaceUnitTests
             bool AskBefore = false;
 
             // test basic replacement
-            target.ReplaceAll(AskBefore);           
+            target.ShowReplaceAllConfirmationPrompt = AskBefore;
+            target.ReplaceAll();
             Assert.AreEqual(Editors[0].Text, @"Hallo 1 bla bla Hallo2 Hallo 3. xxx test tesssst");
 
             // test wrapping through all open files
             target.SearchIn = FindReplaceMgr.SearchScope.AllDocuments;
             target.TextToFind = "bla";
-            target.ReplaceAll(AskBefore);            
+            target.ShowReplaceAllConfirmationPrompt = AskBefore;
+            target.ReplaceAll();
             Assert.AreEqual(Editors[2].Text, @"Hallo 1 xxx xxx Hallo2 Hallo 3. Testen testen test tesssst");
             Assert.AreEqual(Editors[1].Text, @"Hallo 1 xxx xxx Hallo2 Hallo 3. Testen testen test tesssst");
             Assert.AreEqual(Editors[0].Text, @"Hallo 1 xxx xxx Hallo2 Hallo 3. xxx test tesssst");
@@ -197,7 +199,8 @@ namespace FindReplaceUnitTests
             target.UseWildcards = true;
             target.CaseSensitive = true;
             target.TextToFind = "tes*st";
-            target.ReplaceAll(AskBefore);
+            target.ShowReplaceAllConfirmationPrompt = AskBefore;
+            target.ReplaceAll();
             Assert.AreEqual(Editors[2].Text, @"Hallo 1 xxx xxx Hallo2 Hallo 3. Testen xxx");
             Assert.AreEqual(Editors[1].Text, @"Hallo 1 xxx xxx Hallo2 Hallo 3. Testen xxx");
             Assert.AreEqual(Editors[0].Text, @"Hallo 1 xxx xxx Hallo2 Hallo 3. xxx xxx");


### PR DESCRIPTION
Changed this because the replace all confirmation prompt caused some problems with my project.
The prompt would for some reason never appear in front of my window???
Tried everything, nothing worked, so I introduced this property.

Ps: made sure tests  pass and even tested manually again.